### PR TITLE
Guard FTS5 virtual table and trigger creation to ensure migration

### DIFF
--- a/src/context_portal_mcp/db/database.py
+++ b/src/context_portal_mcp/db/database.py
@@ -251,78 +251,84 @@ def upgrade() -> None:
     op.execute("INSERT INTO product_context (id, content) VALUES (1, '{}')")
     op.execute("INSERT INTO active_context (id, content) VALUES (1, '{}')")
 
-    # Create FTS5 virtual table for decisions
-    op.execute('''
-    CREATE VIRTUAL TABLE decisions_fts USING fts5(
-        summary,
-        rationale,
-        implementation_details,
-        tags,
-        content="decisions",
-        content_rowid="id"
-    );
-    ''')
+    # Create FTS5 virtual table for decisions (guarded)
+    try:
+        op.execute('''
+        CREATE VIRTUAL TABLE decisions_fts USING fts5(
+            summary,
+            rationale,
+            implementation_details,
+            tags,
+            content="decisions",
+            content_rowid="id"
+        );
+        ''')
 
-    # Create triggers to keep the FTS table in sync with the decisions table
-    op.execute('''
-    CREATE TRIGGER decisions_after_insert AFTER INSERT ON decisions
-    BEGIN
-        INSERT INTO decisions_fts (rowid, summary, rationale, implementation_details, tags)
-        VALUES (new.id, new.summary, new.rationale, new.implementation_details, new.tags);
-    END;
-    ''')
-    op.execute('''
-    CREATE TRIGGER decisions_after_delete AFTER DELETE ON decisions
-    BEGIN
-        INSERT INTO decisions_fts (decisions_fts, rowid, summary, rationale, implementation_details, tags)
-        VALUES ('delete', old.id, old.summary, old.rationale, old.implementation_details, old.tags);
-    END;
-    ''')
-    op.execute('''
-    CREATE TRIGGER decisions_after_update AFTER UPDATE ON decisions
-    BEGIN
-        INSERT INTO decisions_fts (decisions_fts, rowid, summary, rationale, implementation_details, tags)
-        VALUES ('delete', old.id, old.summary, old.rationale, old.implementation_details, old.tags);
-        INSERT INTO decisions_fts (rowid, summary, rationale, implementation_details, tags)
-        VALUES (new.id, new.summary, new.rationale, new.implementation_details, new.tags);
-    END;
-    ''')
+        # Create triggers to keep the FTS table in sync with the decisions table
+        op.execute('''
+        CREATE TRIGGER decisions_after_insert AFTER INSERT ON decisions
+        BEGIN
+            INSERT INTO decisions_fts (rowid, summary, rationale, implementation_details, tags)
+            VALUES (new.id, new.summary, new.rationale, new.implementation_details, new.tags);
+        END;
+        ''')
+        op.execute('''
+        CREATE TRIGGER decisions_after_delete AFTER DELETE ON decisions
+        BEGIN
+            INSERT INTO decisions_fts (decisions_fts, rowid, summary, rationale, implementation_details, tags)
+            VALUES ('delete', old.id, old.summary, old.rationale, old.implementation_details, old.tags);
+        END;
+        ''')
+        op.execute('''
+        CREATE TRIGGER decisions_after_update AFTER UPDATE ON decisions
+        BEGIN
+            INSERT INTO decisions_fts (decisions_fts, rowid, summary, rationale, implementation_details, tags)
+            VALUES ('delete', old.id, old.summary, old.rationale, old.implementation_details, old.tags);
+            INSERT INTO decisions_fts (rowid, summary, rationale, implementation_details, tags)
+            VALUES (new.id, new.summary, new.rationale, new.implementation_details, new.tags);
+        END;
+        ''')
+    except Exception as e:
+        print(f"Warning: decisions FTS5 not created: {e}")
 
-    # Create FTS5 virtual table for custom_data
-    op.execute('''
-    CREATE VIRTUAL TABLE custom_data_fts USING fts5(
-        category,
-        key,
-        value_text,
-        content="custom_data",
-        content_rowid="id"
-    );
-    ''')
+    # Create FTS5 virtual table for custom_data (guarded)
+    try:
+        op.execute('''
+        CREATE VIRTUAL TABLE custom_data_fts USING fts5(
+            category,
+            key,
+            value_text,
+            content="custom_data",
+            content_rowid="id"
+        );
+        ''')
 
-    # Create triggers for custom_data_fts
-    op.execute('''
-    CREATE TRIGGER custom_data_after_insert AFTER INSERT ON custom_data
-    BEGIN
-        INSERT INTO custom_data_fts (rowid, category, key, value_text)
-        VALUES (new.id, new.category, new.key, new.value);
-    END;
-    ''')
-    op.execute('''
-    CREATE TRIGGER custom_data_after_delete AFTER DELETE ON custom_data
-    BEGIN
-        INSERT INTO custom_data_fts (custom_data_fts, rowid, category, key, value_text)
-        VALUES ('delete', old.id, old.category, old.key, old.value);
-    END;
-    ''')
-    op.execute('''
-    CREATE TRIGGER custom_data_after_update AFTER UPDATE ON custom_data
-    BEGIN
-        INSERT INTO custom_data_fts (custom_data_fts, rowid, category, key, value_text)
-        VALUES ('delete', old.id, old.category, old.key, old.value);
-        INSERT INTO custom_data_fts (rowid, category, key, value_text)
-        VALUES (new.id, new.category, new.key, new.value);
-    END;
-    ''')
+        # Create triggers for custom_data_fts
+        op.execute('''
+        CREATE TRIGGER custom_data_after_insert AFTER INSERT ON custom_data
+        BEGIN
+            INSERT INTO custom_data_fts (rowid, category, key, value_text)
+            VALUES (new.id, new.category, new.key, new.value);
+        END;
+        ''')
+        op.execute('''
+        CREATE TRIGGER custom_data_after_delete AFTER DELETE ON custom_data
+        BEGIN
+            INSERT INTO custom_data_fts (custom_data_fts, rowid, category, key, value_text)
+            VALUES ('delete', old.id, old.category, old.key, old.value);
+        END;
+        ''')
+        op.execute('''
+        CREATE TRIGGER custom_data_after_update AFTER UPDATE ON custom_data
+        BEGIN
+            INSERT INTO custom_data_fts (custom_data_fts, rowid, category, key, value_text)
+            VALUES ('delete', old.id, old.category, old.key, old.value);
+            INSERT INTO custom_data_fts (rowid, category, key, value_text)
+            VALUES (new.id, new.category, new.key, new.value);
+        END;
+        ''')
+    except Exception as e:
+        print(f"Warning: custom_data FTS5 not created: {e}")
     # ### end Alembic commands ###
 
 


### PR DESCRIPTION
PR description (paste this)
Title: Guard FTS5 virtual table/trigger creation to ensure portable migrations

Summary:

Problem: SQLite migrations failed when FTS5 was unavailable, causing DB init to abort.
Change: Wrap creation of FTS5 virtual tables and associated triggers in try/except to gracefully degrade when FTS5 isn’t present.
Behavior: No change when FTS5 is available; schema initializes cleanly otherwise.
Details:

File: 
src/context_portal_mcp/db/database.py
Section: INITIAL_SCHEMA_CONTENT migration string
Guarded:
decisions_fts
 VT + decisions_after_* triggers
custom_data_fts VT + custom_data_after_* triggers
On failure, prints a warning and continues base schema creation.
Testing:

Ran dev MCP from fork via uv, pointed Windsurf MCP to local repo.
Deleted 
kstack/context_portal/context.db
 and re-initialized.
Verified:
get_product_context
 / 
get_active_context
 succeed on fresh DB.
System pattern creation/logging works.
No fatal migration errors; warnings appear only if FTS5 is not available.
Notes:

Minimal patch; no new migration heads or schema reorderings.
Compatible with existing deployments.
Optional follow-ups
If the project prefers logging over print for migration guards, I can switch to logging.getLogger(__name__).warning(...) in the migration template.
Add a config flag to record fts availability in critical_settings.
Status
Fix implemented and tested locally.
Branch rebased on upstream/main and pushed.
Ready for review.