### PR TITLE
feat(cli): add --base-path argument for custom storage location

### DIFF
--- a/src/context_portal_mcp/core/config.py
+++ b/src/context_portal_mcp/core/config.py
@@ -9,6 +9,9 @@ log = logging.getLogger(__name__)
 
 # Global variable to store custom database path
 _custom_db_path: Optional[str] = None
+_base_path: Optional[str] = None
+_db_filename: str = "context.db"
+
 
 def set_custom_db_path(path: Optional[str]):
     """Set a custom database path."""
@@ -16,6 +19,20 @@ def set_custom_db_path(path: Optional[str]):
     _custom_db_path = path
     if path:
         log.info(f"Custom database path set to: {path}")
+
+def set_base_path(path: Optional[str]):
+    """Set a base database path."""
+    global _base_path
+    _base_path = path
+    if path:
+        log.info(f"Base path set to: {path}")
+
+def set_db_filename(filename: str):
+    """Set the database filename."""
+    global _db_filename
+    _db_filename = filename
+    log.info(f"Database filename set to: {filename}")
+
 
 def get_database_path(workspace_id: str) -> pathlib.Path:
     log.debug(f"get_database_path received workspace_id: {workspace_id}")
@@ -31,6 +48,16 @@ def get_database_path(workspace_id: str) -> pathlib.Path:
     Raises:
         ValueError: If the workspace_id is invalid or the path cannot be determined.
     """
+    # Check if base database path is set
+    if _base_path:
+        base_path = pathlib.Path(_base_path).expanduser()
+        sanitized_workspace_id = workspace_id.replace('/', '_').replace('\\', '_')
+        db_dir = base_path / sanitized_workspace_id
+        db_dir.mkdir(parents=True, exist_ok=True)
+        db_path = db_dir / _db_filename
+        log.debug(f"Using base database path: {db_path}")
+        return db_path
+
     # Check if custom database path is set
     if _custom_db_path:
         custom_path = pathlib.Path(_custom_db_path)
@@ -67,6 +94,7 @@ def get_database_path(workspace_id: str) -> pathlib.Path:
     log.debug(f"Constructed db_dir: {db_dir}")
     log.debug(f"Attempting mkdir for: {db_dir}")
     db_dir.mkdir(exist_ok=True) # Ensure the directory exists
-    db_path = db_dir / "context.db"
+    db_path = db_dir / _db_filename
     log.debug(f"Constructed db_path: {db_path}")
     return db_path
+

--- a/src/context_portal_mcp/db/database.py
+++ b/src/context_portal_mcp/db/database.py
@@ -358,13 +358,13 @@ def get_db_connection(workspace_id: str) -> sqlite3.Connection:
 
     # 1. Ensure all necessary directories and Alembic files are present.
     # This is the core of the deferred initialization.
-    ensure_alembic_files_exist(Path(workspace_id))
+    ensure_alembic_files_exist(workspace_id)
 
     # 2. Get the database path (which should now exist within the created directories).
     db_path = get_database_path(workspace_id)
     
     # 3. Run migrations to create/update the database schema.
-    run_migrations(db_path, Path(workspace_id))
+    run_migrations(db_path)
 
     # 4. Establish and cache the database connection.
     try:
@@ -393,7 +393,7 @@ def close_all_connections():
 
 # --- Alembic Migration Integration ---
 
-def ensure_alembic_files_exist(workspace_root_dir: Path):
+def ensure_alembic_files_exist(workspace_id: str):
     """
     Ensures that alembic.ini and the alembic/ directory exist within the
     database directory. If not, copies them from the server's internal templates.
@@ -401,7 +401,7 @@ def ensure_alembic_files_exist(workspace_root_dir: Path):
     # The actual directory where context.db resides and where Alembic files should be
     # Get the database path to determine where Alembic files should be located
     from ..core.config import get_database_path
-    db_path = get_database_path(str(workspace_root_dir))
+    db_path = get_database_path(workspace_id)
     conport_db_dir = db_path.parent
     conport_db_dir.mkdir(exist_ok=True, parents=True) # Ensure this directory exists
 
@@ -444,7 +444,7 @@ def ensure_alembic_files_exist(workspace_root_dir: Path):
             log.error(f"Failed to create initial schema at {initial_schema_path}: {e}")
             raise DatabaseError(f"Could not create initial schema: {e}")
 
-def run_migrations(db_path: Path, workspace_root_dir: Path):
+def run_migrations(db_path: Path):
     """
     Runs Alembic migrations to upgrade the database to the latest version.
     This function is called on database connection to ensure schema is up-to-date.

--- a/src/context_portal_mcp/db/database.py
+++ b/src/context_portal_mcp/db/database.py
@@ -396,12 +396,14 @@ def close_all_connections():
 def ensure_alembic_files_exist(workspace_root_dir: Path):
     """
     Ensures that alembic.ini and the alembic/ directory exist within the
-    workspace's context_portal directory. If not, copies them from the
-    server's internal templates.
+    database directory. If not, copies them from the server's internal templates.
     """
     # The actual directory where context.db resides and where Alembic files should be
-    conport_db_dir = workspace_root_dir / "context_portal"
-    conport_db_dir.mkdir(exist_ok=True) # Ensure this directory exists
+    # Get the database path to determine where Alembic files should be located
+    from ..core.config import get_database_path
+    db_path = get_database_path(str(workspace_root_dir))
+    conport_db_dir = db_path.parent
+    conport_db_dir.mkdir(exist_ok=True, parents=True) # Ensure this directory exists
 
     alembic_ini_path = conport_db_dir / "alembic.ini"
     alembic_dir_path = conport_db_dir / "alembic"
@@ -446,10 +448,11 @@ def run_migrations(db_path: Path, workspace_root_dir: Path):
     """
     Runs Alembic migrations to upgrade the database to the latest version.
     This function is called on database connection to ensure schema is up-to-date.
+    Alembic files are expected to be in the same directory as the database file.
     """
     # The directory where alembic.ini and alembic/ scripts are expected to be,
     # which is now the same directory as the database file.
-    alembic_config_and_scripts_dir = workspace_root_dir / "context_portal"
+    alembic_config_and_scripts_dir = db_path.parent
 
     alembic_ini_path = alembic_config_and_scripts_dir / "alembic.ini"
     alembic_scripts_path = alembic_config_and_scripts_dir / "alembic"

--- a/src/context_portal_mcp/main.py
+++ b/src/context_portal_mcp/main.py
@@ -846,6 +846,13 @@ def main_logic(sys_args=None):
         help="Path to a file where logs should be written, relative to the context_portal directory. Defaults to 'logs/conport.log'."
     )
     parser.add_argument(
+        "--db-path",
+        type=str,
+        required=False,
+        help="Custom database file path (absolute or relative to workspace). "
+             "Defaults to 'context_portal/context.db' in workspace."
+    )
+    parser.add_argument(
         "--log-level",
         type=str,
         default="INFO",
@@ -857,6 +864,12 @@ def main_logic(sys_args=None):
 
     # Configure logging based on the parsed arguments
     setup_logging(args)
+
+    # Set custom database path if provided
+    if args.db_path:
+        from .core import config
+        config.set_custom_db_path(args.db_path)
+        log.info(f"Using custom database path: {args.db_path}")
 
     log.info(f"Parsed CLI args: {args}")
 


### PR DESCRIPTION
Introduces a new `--base-path` command-line argument, allowing users to specify an
a base path to store database and log files, organized by workspace ID

This enhancement provides greater flexibility for users to manage where their
Context Portal data is stored.