### PR TITLE
fix: use Json[T] for strict mode schema compatibility

### DIFF
--- a/CONPORT_SCHEMA_FIX.md
+++ b/CONPORT_SCHEMA_FIX.md
@@ -1,0 +1,66 @@
+# ConPort MCP Server Schema Fix for OpenAI Compatibility
+
+## Problem
+
+OpenAI's strict mode (typically required for agentic workflows or gpt-5.x) enforces `additionalProperties: false` on all JSON objects in the schema. This conflicts with `Dict[str, Any]` fields used in ConPort (e.g., `content`, `patch_content`), which by definition allow arbitrary properties.
+
+The previous proposed "fix" of forcing `additionalProperties: false` on these dictionary fields effectively **breaks them**, making it impossible to pass any actual content (since any key would be considered an forbidden "additional property").
+
+## Solution: Use Pydantic's `Json` Type
+
+The robust solution is to change the field type from `Dict[str, Any]` to `Json[Dict[str, Any]]`. 
+
+This tells Pydantic to expect a **JSON-encoded string** as input, which it will automatically parse into a dictionary.
+- **Schema:** The generated JSON Schema type becomes `"string"`.
+- **Strict Mode:** Strings do not require `additionalProperties: false` validation, so this passes OpenAI's check.
+- **Functionality:** Clients can still pass arbitrary complex objects, they just need to serialized them to a string first.
+
+### Code Fix
+
+Modify `src/context_portal_mcp/db/models.py`:
+
+```python
+from pydantic import BaseModel, Field, Json, model_validator
+from typing import Optional, Dict, Any
+
+class UpdateContextArgs(BaseArgs):
+    """Arguments for updating product or active context.
+    Provide either 'content' for a full update or 'patch_content' for a partial update.
+    """
+    # Change type to Json[Dict[str, Any]]
+    content: Optional[Json[Dict[str, Any]]] = Field(None, description="The full new context content as a JSON string. Overwrites existing.")
+    patch_content: Optional[Json[Dict[str, Any]]] = Field(None, description="A JSON string of changes to apply to the existing context (add/update keys).")
+
+    @model_validator(mode='before')
+    @classmethod
+    def check_content_or_patch(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        content, patch_content = values.get('content'), values.get('patch_content')
+        if content is None and patch_content is None:
+            raise ValueError("Either 'content' or 'patch_content' must be provided.")
+        if content is not None and patch_content is not None:
+            raise ValueError("Provide either 'content' for a full update or 'patch_content' for a partial update, not both.")
+        return values
+```
+
+You should also apply this pattern to any other model using `Dict[str, Any]` (e.g., `LogCustomDataArgs`).
+
+### Impact on Clients
+
+This is a **breaking change** for clients, but a necessary one for Strict Mode support.
+- **Old Usage:** `update_product_context(content={"goals": "..."})`
+- **New Usage:** `update_product_context(content='{"goals": "..."}')`
+
+Most MCP clients and LLMs handle this gracefully. The schema description explicitly states it expects a JSON string.
+
+## Verification
+
+The generated schema for `content` will look like:
+```json
+{
+  "title": "Content", 
+  "description": "The full new context content as a JSON string...", 
+  "default": null, 
+  "type": "string"
+}
+```
+This is fully compatible with OpenAI Strict Mode.

--- a/src/context_portal_mcp/db/models.py
+++ b/src/context_portal_mcp/db/models.py
@@ -111,8 +111,8 @@ class UpdateContextArgs(BaseArgs):
     """Arguments for updating product or active context.
     Provide either 'content' for a full update or 'patch_content' for a partial update.
     """
-    content: Optional[Dict[str, Any]] = Field(None, description="The full new context content as a dictionary. Overwrites existing.")
-    patch_content: Optional[Dict[str, Any]] = Field(None, description="A dictionary of changes to apply to the existing context (add/update keys).")
+    content: Optional[Json[Dict[str, Any]]] = Field(None, description="The full new context content as a JSON string. Overwrites existing.")
+    patch_content: Optional[Json[Dict[str, Any]]] = Field(None, description="A JSON string of changes to apply to the existing context (add/update keys).")
 
     @model_validator(mode='before')
     @classmethod
@@ -290,7 +290,7 @@ class LogCustomDataArgs(BaseArgs):
     """Arguments for logging custom data."""
     category: str = Field(..., min_length=1, description="Category for the custom data")
     key: str = Field(..., min_length=1, description="Key for the custom data (unique within category)")
-    value: Any = Field(..., description="The custom data value (JSON serializable)")
+    value: Json[Any] = Field(..., description="The custom data value (JSON string)")
 
 class GetCustomDataArgs(BaseArgs):
     """Arguments for retrieving custom data."""
@@ -381,7 +381,7 @@ class GetLinkedItemsArgs(IntCoercionMixin, BaseArgs):
 class BatchLogItemsArgs(BaseArgs):
     """Arguments for batch logging multiple items of the same type."""
     item_type: str = Field(..., description="Type of items to log (e.g., 'decision', 'progress_entry', 'system_pattern', 'custom_data')")
-    items: List[Dict[str, Any]] = Field(..., description="A list of dictionaries, each representing the arguments for a single item log.")
+    items: Json[List[Dict[str, Any]]] = Field(..., description="A JSON string list of dictionaries, each representing the arguments for a single item log.")
 
 # --- Context History Tool Args ---
 

--- a/tests/test_schema_models.py
+++ b/tests/test_schema_models.py
@@ -1,0 +1,45 @@
+import pytest
+from pydantic import ValidationError
+from context_portal_mcp.db.models import UpdateContextArgs, LogCustomDataArgs, BatchLogItemsArgs
+
+def test_fields_are_json_strings():
+    """Verify that complex fields are exposed as strings in the JSON schema for strict mode compatibility."""
+    
+    # 1. UpdateContextArgs.content
+    schema = UpdateContextArgs.model_json_schema()
+    prop = schema['properties']['content']
+    # Checking for 'anyOf' containing a string type or direct string type
+    is_any_of = 'anyOf' in prop
+    types = [x.get('type') for x in prop.get('anyOf', [])] if is_any_of else [prop.get('type')]
+    assert 'string' in types, "UpdateContextArgs.content schema must allow string type"
+
+    # 2. LogCustomDataArgs.value
+    schema = LogCustomDataArgs.model_json_schema()
+    prop = schema['properties']['value']
+    # Json[Any] typically results in type: string
+    assert prop.get('type') == 'string', "LogCustomDataArgs.value schema must be string"
+
+    # 3. BatchLogItemsArgs.items
+    schema = BatchLogItemsArgs.model_json_schema()
+    prop = schema['properties']['items']
+    assert prop.get('type') == 'string', "BatchLogItemsArgs.items schema must be string"
+
+def test_json_string_parsing():
+    """Verify that Pydantic correctly parses JSON strings into their target Python types."""
+    
+    # 1. UpdateContextArgs
+    obj = UpdateContextArgs(workspace_id="test", content='{"foo": "bar"}')
+    assert isinstance(obj.content, dict)
+    assert obj.content == {"foo": "bar"}
+
+    # 2. LogCustomDataArgs
+    obj = LogCustomDataArgs(workspace_id="test", category="c", key="k", value='[1, 2, 3]')
+    assert isinstance(obj.value, list)
+    assert obj.value == [1, 2, 3]
+
+    # 3. BatchLogItemsArgs
+    json_list = '[{"summary": "item1"}, {"summary": "item2"}]'
+    obj = BatchLogItemsArgs(workspace_id="test", item_type="decision", items=json_list)
+    assert isinstance(obj.items, list)
+    assert len(obj.items) == 2
+    assert obj.items[0]["summary"] == "item1"


### PR DESCRIPTION
Fixes #73

This PR addresses the OpenAI Strict Mode schema compatibility issue by changing `Dict[str, Any]` fields to `Json[Dict[str, Any]]`. This ensures the generated JSON Schema uses `type: string` for these fields, which avoids `additionalProperties: false` validation errors while still allowing arbitrary dictionary content (passed as JSON strings).

**Changes:**
- Updated `UpdateContextArgs`, `LogCustomDataArgs`, and `BatchLogItemsArgs` to use `Json` wrapped types.
- Added regression test `tests/test_schema_models.py`.

**Breaking Change:**
Clients must now serialize content/value objects to JSON strings before calling these tools.

Credit to @pwpeterson for reporting the issue.